### PR TITLE
Retrowrite can only handle Position-Independent Executables

### DIFF
--- a/librw/loader.py
+++ b/librw/loader.py
@@ -16,7 +16,11 @@ class Loader():
         self.fd = open(fname, 'rb')
         self.elffile = ELFFile(self.fd)
         self.container = Container()
-        print(self.elffile['e_type'])
+
+    def is_pie(self):
+        base_address = next(seg for seg in self.elffile.iter_segments() 
+                                        if seg['p_type'] == "PT_LOAD")['p_vaddr']
+        return self.elffile['e_type'] == 'ET_DYN' and base_address == 0
 
     def load_functions(self, fnlist):
         section = self.elffile.get_section_by_name(".text")

--- a/librw/rw.py
+++ b/librw/rw.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from collections import defaultdict
 
 from capstone import CS_OP_IMM, CS_GRP_JUMP, CS_GRP_CALL, CS_OP_MEM
@@ -388,10 +389,17 @@ if __name__ == "__main__":
 
     argp.add_argument("bin", type=str, help="Input binary to load")
     argp.add_argument("outfile", type=str, help="Symbolized ASM output")
+    argp.add_argument("--ignorepie", dest="ignorepie", action='store_true', help="Ignore position-independent-executable check (use with caution)")
+    argp.set_defaults(ignorepie=False)
 
     args = argp.parse_args()
 
     loader = Loader(args.bin)
+
+    if loader.is_pie() == False and args.ignorepie == False:
+        print("RetroWrite requires a position-independent executable.")
+        print("It looks like %s is not position independent" % args.bin)
+        sys.Exit(1)
 
     flist = loader.flist_from_symtab()
     loader.load_functions(flist)

--- a/retrowrite
+++ b/retrowrite
@@ -4,8 +4,8 @@ import argparse
 import json
 import tempfile
 import subprocess
-
-
+import os
+import sys
 
 def load_analysis_cache(loader, outfile):
     with open(outfile + ".analysis_cache") as fd:
@@ -95,8 +95,8 @@ if __name__ == "__main__":
         "--kcov", action='store_true', help="Instrument the kernel module with kcov")
     argp.add_argument("-c", "--cache", action='store_true',
                       help="Save/load register analysis cache (only used with --asan)")
-
-
+    argp.add_argument("--ignorepie", dest="ignorepie", action='store_true', help="Ignore position-independent-executable check (use with caution)")
+    argp.set_defaults(ignorepie=False)
     args = argp.parse_args()
 
     if args.kernel:
@@ -121,6 +121,11 @@ if __name__ == "__main__":
 
 
     loader = Loader(args.bin)
+    if loader.is_pie() == False and args.ignorepie == False:
+        print("***** RetroWrite requires a position-independent executable. *****")
+        print("It looks like %s is not position independent" % args.bin)
+        print("If you really want to continue, because you think retrowrite has made a mistake, pass --ignorepie.")
+        sys.exit(1)
 
     flist = loader.flist_from_symtab()
     loader.load_functions(flist)


### PR DESCRIPTION
This patch adds logic to check for a position independent executable
and will refuse to run if the executable does not look to be PIE.

An option --ignorepie exists to suppress this check (for example if
for some reason the check is not valid on different architectures).

This may not fix retrowrite in all cases. In particular there appears to be multiple "retrowrite" commands, both librw/rw.py and retrowrite itself. There should not be as this is just a maintenance nightmare. 

You can add multiple binary entrypoints in the `setup.py` of a python setuptools project, i.e. here is my WIP for Halucinator:

```python
setup(name='halucinator',
      version='1.0a',
      description='Emulation and rehosting framework',
      author='Abe Clements and Eric Gustafson',
      author_email='',
      # url='https://seclab.cs.ucsb.edu',
      packages=get_packages('halucinator'),
      entry_points ={'console_scripts': [
            'halucinator-periph = halucinator.commands.peripheral:main',
            'halucinator-rehost = halucinator.commands.rehost:main',
            'ghalucinator = halucinator.commands.gui:main'
        ]},
      requires=['avatar2',
                'zeromq',
                'PyYAML',
                'IPython', ])
```

these will all be binaries installed to the system (or pip virtualenv) which will also avoid the link step in setup.sh.

cc @gannimo 