### PR TITLE
change basic block label format from .L%x to .L%d

### DIFF
--- a/librw/container.py
+++ b/librw/container.py
@@ -188,7 +188,7 @@ class Function():
                 continue
 
             if instruction.address in self.bbstarts:
-                results.append(".L%x:" % (instruction.address))
+                results.append(".L%d:" % (instruction.address))
                 results.append(".LC%x:" % (instruction.address))
             else:
                 results.append(".LC%x:" % (instruction.address))

--- a/librw/rw.py
+++ b/librw/rw.py
@@ -187,7 +187,7 @@ class Symbolizer():
                     # Check if the target is in .text section.
                     if container.is_in_section(".text", target):
                         function.bbstarts.add(target)
-                        instruction.op_str = ".L%x" % (target)
+                        instruction.op_str = ".L%d" % (target)
                     elif target in container.plt:
                         instruction.op_str = "{}@PLT".format(
                             container.plt[target])


### PR DESCRIPTION
Using `.L%x` could miss some instrumentations when instrumenting binary with AFL.